### PR TITLE
Fix pull request badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![DocLense](./readme_assets/doclense_banner.png)
 
 ![Issues](https://img.shields.io/github/issues/smaranjitghose/DocLense)
-![Pull Requests](https://img.shields.io/github/issues-pr/smaranjitghose/DocLense?)
+![Pull Requests](https://img.shields.io/github/issues-pr/smaranjitghose/DocLense)
 ![Forks](https://img.shields.io/github/forks/smaranjitghose/DocLense)
 ![Stars](https://img.shields.io/github/stars/smaranjitghose/DocLense)
 ![License](https://img.shields.io/github/license/smaranjitghose/DocLense)


### PR DESCRIPTION
## Summary
- fix README link for Pull Requests badge

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f96c264d0832aa4c3bb307514d669